### PR TITLE
Formatter and grammar improvements

### DIFF
--- a/ApexParser/ApexCodeFormatter/FormatApexCode.cs
+++ b/ApexParser/ApexCodeFormatter/FormatApexCode.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using ApexParser.Lexer;
 
@@ -22,7 +23,7 @@ namespace ApexParser.ApexCodeFormatter
             TokenType.KwVoid
         };
 
-        public static string GetFormatedApexCode(string apexCode)
+        public static string GetFormattedApexCode(string apexCode)
         {
             var formatedApexCode = FormatApexCodeNoIndent(apexCode);
             var indentedApexCode = IndentApexCode(formatedApexCode);
@@ -169,13 +170,9 @@ namespace ApexParser.ApexCodeFormatter
             return newApexCodeList;
         }
 
-        private static bool IsEmptyGetterOrSetter(string line)
-        {
-            line = line.Trim();
-
-            return line == "get;" || line == "set;" ||
-                line == "get; set;" || line == "set; get;";
-        }
+        // Detects empty getters and setters in any order
+        private static bool IsEmptyGetterOrSetter(string line) =>
+            Regex.IsMatch(line, @"^((get|set)\s*\;\s*)+$");
 
         public static string IndentApexCode(List<string> apexCodeList)
         {

--- a/ApexParser/ApexCodeFormatter/FormatApexCode.cs
+++ b/ApexParser/ApexCodeFormatter/FormatApexCode.cs
@@ -190,6 +190,10 @@ namespace ApexParser.ApexCodeFormatter
                     padding = padding - IndentSize;
                     needExtraLine = true;
                 }
+                else if (apexCode.Trim().EndsWith("}"))
+                {
+                    needExtraLine = true;
+                }
                 else if (needExtraLine)
                 {
                     sb.AppendLine();

--- a/ApexParser/ApexParser.csproj
+++ b/ApexParser/ApexParser.csproj
@@ -66,6 +66,7 @@
     <Compile Include="MetaClass\ConstructorSyntax.cs" />
     <Compile Include="MetaClass\ParameterSyntax.cs" />
     <Compile Include="MetaClass\MethodSyntax.cs" />
+    <Compile Include="MetaClass\PropertySyntax.cs" />
     <Compile Include="MetaClass\SyntaxType.cs" />
     <Compile Include="MetaClass\TypeSyntax.cs" />
     <Compile Include="Parser\ApexGrammar.cs" />

--- a/ApexParser/ApexParser.csproj
+++ b/ApexParser/ApexParser.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Lexer\TokenType.cs" />
     <Compile Include="Lexer\TokenDefinition.cs" />
     <Compile Include="MetaClass\BaseSyntax.cs" />
+    <Compile Include="MetaClass\ClassMemberSyntax.cs" />
     <Compile Include="MetaClass\ClassSyntax.cs" />
     <Compile Include="MetaClass\ConstructorSyntax.cs" />
     <Compile Include="MetaClass\ParameterSyntax.cs" />

--- a/ApexParser/MetaClass/ClassMemberSyntax.cs
+++ b/ApexParser/MetaClass/ClassMemberSyntax.cs
@@ -10,12 +10,19 @@ namespace ApexParser.MetaClass
     {
         public ClassMemberSyntax(ClassMemberSyntax other = null)
         {
+            CopyProperties(other);
+        }
+
+        public ClassMemberSyntax CopyProperties(ClassMemberSyntax other = null)
+        {
             if (other != null)
             {
                 CodeComments = other.CodeComments;
                 Attributes = other.Attributes;
                 Modifiers = other.Modifiers;
             }
+
+            return this;
         }
 
         public List<string> Attributes { get; set; } = new List<string>();

--- a/ApexParser/MetaClass/ClassMemberSyntax.cs
+++ b/ApexParser/MetaClass/ClassMemberSyntax.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApexParser.MetaClass
+{
+    public class ClassMemberSyntax : BaseSyntax
+    {
+        public ClassMemberSyntax(ClassMemberSyntax other = null)
+        {
+            if (other != null)
+            {
+                CodeComments = other.CodeComments;
+                Attributes = other.Attributes;
+                Modifiers = other.Modifiers;
+            }
+        }
+
+        public List<string> Attributes { get; set; } = new List<string>();
+
+        public List<string> Modifiers { get; set; } = new List<string>();
+    }
+}

--- a/ApexParser/MetaClass/ClassSyntax.cs
+++ b/ApexParser/MetaClass/ClassSyntax.cs
@@ -20,5 +20,7 @@ namespace ApexParser.MetaClass
         public string Identifier { get; set; }
 
         public List<MethodSyntax> Methods { get; set; } = new List<MethodSyntax>();
+
+        public List<PropertySyntax> Properties { get; set; } = new List<PropertySyntax>();
     }
 }

--- a/ApexParser/MetaClass/ClassSyntax.cs
+++ b/ApexParser/MetaClass/ClassSyntax.cs
@@ -6,16 +6,13 @@ using System.Threading.Tasks;
 
 namespace ApexParser.MetaClass
 {
-    public class ClassSyntax : BaseSyntax
+    public class ClassSyntax : ClassMemberSyntax
     {
-        public ClassSyntax()
+        public ClassSyntax(ClassMemberSyntax heading = null)
+            : base(heading)
         {
             Kind = SyntaxType.Class;
         }
-
-        public List<string> Attributes { get; set; } = new List<string>();
-
-        public List<string> Modifiers { get; set; } = new List<string>();
 
         public string Identifier { get; set; }
 

--- a/ApexParser/MetaClass/ClassSyntax.cs
+++ b/ApexParser/MetaClass/ClassSyntax.cs
@@ -19,5 +19,7 @@ namespace ApexParser.MetaClass
         public List<MethodSyntax> Methods { get; set; } = new List<MethodSyntax>();
 
         public List<PropertySyntax> Properties { get; set; } = new List<PropertySyntax>();
+
+        public List<ClassSyntax> InnerClasses { get; set; } = new List<ClassSyntax>();
     }
 }

--- a/ApexParser/MetaClass/MethodSyntax.cs
+++ b/ApexParser/MetaClass/MethodSyntax.cs
@@ -3,16 +3,13 @@ using ApexParser.Lexer;
 
 namespace ApexParser.MetaClass
 {
-    public class MethodSyntax : BaseSyntax
+    public class MethodSyntax : ClassMemberSyntax
     {
-        public MethodSyntax()
+        public MethodSyntax(ClassMemberSyntax heading = null)
+            : base(heading)
         {
             Kind = SyntaxType.Method;
         }
-
-        public List<string> Attributes { get; set; } = new List<string>();
-
-        public List<string> Modifiers { get; set; } = new List<string>();
 
         public TypeSyntax ReturnType { get; set; }
 

--- a/ApexParser/MetaClass/ParameterSyntax.cs
+++ b/ApexParser/MetaClass/ParameterSyntax.cs
@@ -1,6 +1,6 @@
 ﻿namespace ApexParser.MetaClass
 {
-    public class ParameterSyntax
+    public class ParameterSyntax : BaseSyntax
     {
         public ParameterSyntax(string type, string identifier)
             : this(new TypeSyntax(type), identifier)
@@ -11,6 +11,7 @@
         {
             Type = type;
             Identifier = identifier;
+            Kind = SyntaxType.MethodParameter;
         }
 
         public TypeSyntax Type { get; set; }

--- a/ApexParser/MetaClass/PropertySyntax.cs
+++ b/ApexParser/MetaClass/PropertySyntax.cs
@@ -8,11 +8,15 @@ namespace ApexParser.MetaClass
 {
     public class PropertySyntax : ClassMemberSyntax
     {
-        public PropertySyntax(IEnumerable<Tuple<string, string>> gettersOrSetters, ClassMemberSyntax heading = null)
+        public PropertySyntax(ClassMemberSyntax heading = null)
             : base(heading)
         {
             Kind = SyntaxType.Property;
+        }
 
+        public PropertySyntax(IEnumerable<Tuple<string, string>> gettersOrSetters, ClassMemberSyntax heading = null)
+            : this(heading)
+        {
             foreach (var item in gettersOrSetters)
             {
                 switch (item.Item1)

--- a/ApexParser/MetaClass/PropertySyntax.cs
+++ b/ApexParser/MetaClass/PropertySyntax.cs
@@ -6,9 +6,10 @@ using System.Threading.Tasks;
 
 namespace ApexParser.MetaClass
 {
-    public class PropertySyntax : BaseSyntax
+    public class PropertySyntax : ClassMemberSyntax
     {
-        public PropertySyntax(IEnumerable<Tuple<string, string>> gettersOrSetters)
+        public PropertySyntax(IEnumerable<Tuple<string, string>> gettersOrSetters, ClassMemberSyntax heading = null)
+            : base(heading)
         {
             Kind = SyntaxType.Property;
 

--- a/ApexParser/MetaClass/PropertySyntax.cs
+++ b/ApexParser/MetaClass/PropertySyntax.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApexParser.MetaClass
+{
+    public class PropertySyntax : BaseSyntax
+    {
+        public PropertySyntax(IEnumerable<Tuple<string, string>> gettersOrSetters)
+        {
+            Kind = SyntaxType.Property;
+
+            foreach (var item in gettersOrSetters)
+            {
+                switch (item.Item1)
+                {
+                    case "get":
+                        GetterCode = item.Item2;
+                        continue;
+
+                    case "set":
+                        SetterCode = item.Item2;
+                        continue;
+                }
+            }
+        }
+
+        public TypeSyntax Type { get; set; }
+
+        public string Identifier { get; set; }
+
+        public string GetterCode { get; set; }
+
+        public string SetterCode { get; set; }
+    }
+}

--- a/ApexParser/MetaClass/SyntaxType.cs
+++ b/ApexParser/MetaClass/SyntaxType.cs
@@ -6,5 +6,7 @@
         Class,
         Constructor,
         Method,
+        MethodParameter,
+        Property
     }
 }

--- a/ApexParser/Program.cs
+++ b/ApexParser/Program.cs
@@ -15,7 +15,7 @@ namespace ApexParser
             // string myDevdir = @"C:\DevSharp";
             // string apexCode = File.ReadAllText(myDevdir + @"\ApexParser\SalesForceApexSharp\src\classes\ClassDemo.cls");
             string apexCode = File.ReadAllText(@"C:\Dev\nadev12d\src\classes\TestDataFactory.cls");
-            var apexCodeList = FormatApexCode.GetFormatedApexCode(apexCode);
+            var apexCodeList = FormatApexCode.GetFormattedApexCode(apexCode);
             Console.WriteLine(apexCodeList);
             Console.WriteLine("Done");
             Console.ReadLine();

--- a/ApexParserTest/ApexCodeFormatter/FormatterTests.cs
+++ b/ApexParserTest/ApexCodeFormatter/FormatterTests.cs
@@ -9,11 +9,11 @@ namespace ApexParserTest.ApexCodeFormatter
     public class FormatterTests
     {
         private void Validate(string source, string expected) =>
-            Assert.AreEqual(expected, GetFormatedApexCode(source));
+            Assert.AreEqual(expected, GetFormattedApexCode(source));
 
         public void ValidateLineByLine(string source, string expected)
         {
-            var formatted = GetFormatedApexCode(source);
+            var formatted = GetFormattedApexCode(source);
             var formattedList = formatted.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             var expectedList = expected.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
@@ -72,5 +72,9 @@ namespace ApexParserTest.ApexCodeFormatter
         [Test]
         public void FormatDemoIsFormatted() =>
             ValidateLineByLine(FormatDemo, FormatDemo_Formatted);
+
+        [Test]
+        public void CustomerDtoIsFormatted() =>
+            ValidateLineByLine(CustomerDto, CustomerDto_Formatted);
     }
 }

--- a/ApexParserTest/ApexParserTest.csproj
+++ b/ApexParserTest/ApexParserTest.csproj
@@ -110,6 +110,12 @@
   <ItemGroup>
     <None Include="ApexTestClasses\ClassWithComments_Formatted.cls" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="ApexTestClasses\FormatDemo.cls" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ApexTestClasses\FormatDemo_Formatted.cls" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ApexParserTest/ApexParserTest.csproj
+++ b/ApexParserTest/ApexParserTest.csproj
@@ -97,24 +97,14 @@
     <None Include="ApexTestClasses\ClassOne.cls" />
     <None Include="ApexTestClasses\ClassTwo.cls" />
     <None Include="ApexTestClasses\Demo.cls" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="ApexTestClasses\ClassOne_Formatted.cls" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="ApexTestClasses\ClassTwo_Formatted.cls" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="ApexTestClasses\ClassWithComments.cls" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="ApexTestClasses\ClassWithComments_Formatted.cls" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="ApexTestClasses\FormatDemo.cls" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="ApexTestClasses\FormatDemo_Formatted.cls" />
+    <None Include="ApexTestClasses\CustomerDto.cls" />
+    <None Include="ApexTestClasses\CustomerDto_Formatted.cls" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ApexParserTest/ApexTestClasses/ClassWithComments_Formatted.cls
+++ b/ApexParserTest/ApexTestClasses/ClassWithComments_Formatted.cls
@@ -1,15 +1,15 @@
 public with sharing class ClassTwo
 {
-     // constructor
      public ClassTwo()
      {
+          // constructor
           System.debug('Test');
      }
 
-     // another constructor
-     // with a lot of misplaced comments
      public ClassTwo(String vin)
      {
+          // another constructor
+          // with a lot of misplaced comments
      }
 
      /*

--- a/ApexParserTest/ApexTestClasses/CustomerDto.cls
+++ b/ApexParserTest/ApexTestClasses/CustomerDto.cls
@@ -1,0 +1,10 @@
+public class CustomerDto
+{
+    public String make {get;set;}
+    public String year {get;set;}
+    public CustomerDto.User user {get;set;}
+
+    public class User {
+        public string userName {get;set;}
+    }
+}

--- a/ApexParserTest/ApexTestClasses/CustomerDto_Formatted.cls
+++ b/ApexParserTest/ApexTestClasses/CustomerDto_Formatted.cls
@@ -1,0 +1,11 @@
+public class CustomerDto
+{
+     public String make { get;set; }
+     public String year { get;set; }
+     public CustomerDto.User user { get;set; }
+
+     public class User
+     {
+          public string userName { get;set; }
+     }
+}

--- a/ApexParserTest/ApexTestClasses/FormatDemo.cls
+++ b/ApexParserTest/ApexTestClasses/FormatDemo.cls
@@ -1,0 +1,20 @@
+/*
+* This  is a comment line one
+* This is a comment // line two
+*/
+public with sharing class FormatDemo
+{
+    public Integer
+        dateOfBirth
+            { get; set; }
+    public void ForLoopTest() {
+        for (Integer i = 0; i < 10; i++) {
+            List<Contact> contacts =
+            [
+                    SELECT Name, Email // This is a middle line comment
+                    From Contact
+                    Where Name = 'Jay'
+            ];
+        }
+    }
+}

--- a/ApexParserTest/ApexTestClasses/FormatDemo_Formatted.cls
+++ b/ApexParserTest/ApexTestClasses/FormatDemo_Formatted.cls
@@ -5,6 +5,7 @@
 public with sharing class FormatDemo
 {
      public Integer dateOfBirth { get; set; }
+
      public void ForLoopTest()
      {
           for (Integer i = 0; i < 10; i++)

--- a/ApexParserTest/ApexTestClasses/FormatDemo_Formatted.cls
+++ b/ApexParserTest/ApexTestClasses/FormatDemo_Formatted.cls
@@ -1,0 +1,16 @@
+/*
+* This  is a comment line one
+* This is a comment // line two
+*/
+public with sharing class FormatDemo
+{
+     public Integer dateOfBirth { get; set; }
+     public void ForLoopTest()
+     {
+          for (Integer i = 0; i < 10; i++)
+          {
+               // This is a middle line comment
+               List<Contact> contacts = [ SELECT Name, Email From Contact Where Name = 'Jay' ];
+          }
+     }
+}

--- a/ApexParserTest/Parser/ApexGrammarTests.cs
+++ b/ApexParserTest/Parser/ApexGrammarTests.cs
@@ -359,6 +359,46 @@ namespace ApexParserTest.Parser
         }
 
         [Test]
+        public void GetterOrSetterCanBeEmpty()
+        {
+            var get = Apex.GetterOrSetter.Parse(" get ; ");
+            Assert.AreEqual("get", get.Item1);
+            Assert.AreEqual(";", get.Item2);
+
+            var set = Apex.GetterOrSetter.Parse(" set ; ");
+            Assert.AreEqual("set", set.Item1);
+            Assert.AreEqual(";", set.Item2);
+        }
+
+        [Test]
+        public void GetterOrSetterCanHaveBlocks()
+        {
+            var get = Apex.GetterOrSetter.Parse(" get { return myProperty; } ");
+            Assert.AreEqual("get", get.Item1);
+            Assert.AreEqual("return myProperty;", get.Item2);
+
+            var set = Apex.GetterOrSetter.Parse(" set { myProperty = value; while(true) { value++; } } ");
+            Assert.AreEqual("set", set.Item1);
+            Assert.AreEqual("myProperty = value; while(true) { value++; }", set.Item2);
+        }
+
+        [Test]
+        public void PropertyHasTypeNameGettersAndOrSetters()
+        {
+            var prop = Apex.PropertyDeclaration.Parse(" int x { get; }");
+            Assert.AreEqual("int", prop.Type.Identifier);
+            Assert.AreEqual("x", prop.Identifier);
+            Assert.AreEqual(null, prop.SetterCode);
+            Assert.AreEqual(";", prop.GetterCode);
+
+            prop = Apex.PropertyDeclaration.Parse(" String Version { set { version = value; } }");
+            Assert.AreEqual("String", prop.Type.Identifier);
+            Assert.AreEqual("Version", prop.Identifier);
+            Assert.AreEqual(null, prop.GetterCode);
+            Assert.AreEqual("version = value;", prop.SetterCode);
+        }
+
+        [Test]
         public void ClassDeclarationCanBeEmpty()
         {
             var cd = Apex.ClassDeclaration.Parse(" class Test {}");

--- a/ApexParserTest/Parser/ApexResourceTests.cs
+++ b/ApexParserTest/Parser/ApexResourceTests.cs
@@ -193,5 +193,60 @@ namespace ApexParserTest.Parser
                     System.debug('Del Worked');
                 }", md.CodeInsideMethod);
         }
+
+        [Test]
+        public void CustomerDtoIsParsed()
+        {
+            ParseAndValidate(CustomerDto);
+            ParseAndValidate(CustomerDto_Formatted);
+
+            void ParseAndValidate(string text)
+            {
+                var cd = Apex.ClassDeclaration.Parse(text);
+                Assert.False(cd.Attributes.Any());
+                Assert.AreEqual("CustomerDto", cd.Identifier);
+                Assert.AreEqual(1, cd.Modifiers.Count);
+                Assert.AreEqual("public", cd.Modifiers[0]);
+                Assert.AreEqual(3, cd.Properties.Count);
+
+                var pd = cd.Properties[0];
+                Assert.False(pd.Attributes.Any());
+                Assert.AreEqual(1, pd.Modifiers.Count);
+                Assert.AreEqual("public", pd.Modifiers[0]);
+                Assert.AreEqual("String", pd.Type.Identifier);
+                Assert.AreEqual("make", pd.Identifier);
+
+                pd = cd.Properties[1];
+                Assert.False(pd.Attributes.Any());
+                Assert.AreEqual(1, pd.Modifiers.Count);
+                Assert.AreEqual("public", pd.Modifiers[0]);
+                Assert.AreEqual("String", pd.Type.Identifier);
+                Assert.AreEqual("year", pd.Identifier);
+
+                pd = cd.Properties[2];
+                Assert.False(pd.Attributes.Any());
+                Assert.AreEqual(1, pd.Modifiers.Count);
+                Assert.AreEqual("public", pd.Modifiers[0]);
+                Assert.AreEqual("User", pd.Type.Identifier);
+                Assert.AreEqual(1, pd.Type.Namespaces.Count);
+                Assert.AreEqual("CustomerDto", pd.Type.Namespaces[0]);
+                Assert.AreEqual("user", pd.Identifier);
+
+                Assert.AreEqual(1, cd.InnerClasses.Count);
+                cd = cd.InnerClasses[0];
+                Assert.AreEqual("User", cd.Identifier);
+                Assert.False(cd.Attributes.Any());
+                Assert.AreEqual(1, cd.Modifiers.Count);
+                Assert.AreEqual("public", cd.Modifiers[0]);
+                Assert.AreEqual(1, cd.Properties.Count);
+
+                pd = cd.Properties[0];
+                Assert.False(pd.Attributes.Any());
+                Assert.AreEqual(1, pd.Modifiers.Count);
+                Assert.AreEqual("public", pd.Modifiers[0]);
+                Assert.AreEqual("string", pd.Type.Identifier);
+                Assert.AreEqual("userName", pd.Identifier);
+            }
+        }
     }
 }

--- a/ApexParserTest/Parser/ApexResourceTests.cs
+++ b/ApexParserTest/Parser/ApexResourceTests.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using ApexParser.Parser;
 using ApexParserTest.Properties;
 using NUnit.Framework;
 using Sprache;
+using static ApexParserTest.Properties.Resources;
 
 namespace ApexParserTest.Parser
 {
@@ -16,62 +18,180 @@ namespace ApexParserTest.Parser
     {
         private ApexGrammar Apex { get; } = new ApexGrammar();
 
-        // I'll put the original location of the file in the description, for future reference
-        // In case the original file is modified, it should be add as a new resource
-        // Old resource files should not be modified so we don't need to fix the old tests
+        // utility method used to compare method bodies ignoring the formatting
+        private void CompareIgnoreFormatting(string expected, string actual)
+        {
+            var ignoreWhiteSpace = new Regex(@"\s+");
+            expected = ignoreWhiteSpace.Replace(expected, " ").Trim();
+            actual = ignoreWhiteSpace.Replace(actual, " ").Trim();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void CompareIgnoresFormattingDifferences()
+        {
+            CompareIgnoreFormatting(" hello ", "hello");
+            CompareIgnoreFormatting(" hello    world!", "hello world!");
+
+            Assert.Throws<AssertionException>(() => CompareIgnoreFormatting("hello", "world"));
+        }
+
+        // The original file location in the description is kept for future reference.
+        // In case the original file is modified, it should be added as a new resource.
+        // Old resource files should not be modified so that we don't need to fix the old tests.
         [Test(Description = @"\ApexParser\SalesForceApexSharp\src\classes\ClassOne.cls")]
-        public void ClassOneTest()
+        public void ClassOneIsParsed()
         {
-            var cd = Apex.ClassDeclaration.Parse(Resources.ClassOne);
-            Assert.AreEqual("ClassOne", cd.Identifier);
-            Assert.AreEqual(1, cd.Methods.Count);
+            // formatted version should have the same AST as the original
+            ParseAndValidate(ClassOne);
+            ParseAndValidate(ClassOne_Formatted);
 
-            var md = cd.Methods[0];
-            Assert.AreEqual("CallClassTwo", md.Identifier);
-            Assert.False(md.CodeComments.Any());
-            Assert.False(md.Attributes.Any());
-            Assert.AreEqual(1, md.Modifiers.Count);
-            Assert.AreEqual("public", md.Modifiers[0]);
-            Assert.AreEqual("void", md.ReturnType.Identifier);
-            Assert.AreEqual(@"ClassTwo classTwo = new ClassTwo();
-        System.debug('Test');", md.CodeInsideMethod);
+            // use local functions to share the validation code
+            void ParseAndValidate(string text)
+            {
+                var cd = Apex.ClassDeclaration.Parse(text);
+                Assert.AreEqual("ClassOne", cd.Identifier);
+                Assert.AreEqual(1, cd.Methods.Count);
+
+                var md = cd.Methods[0];
+                Assert.AreEqual("CallClassTwo", md.Identifier);
+                Assert.False(md.CodeComments.Any());
+                Assert.False(md.Attributes.Any());
+                Assert.AreEqual(1, md.Modifiers.Count);
+                Assert.AreEqual("public", md.Modifiers[0]);
+                Assert.AreEqual("void", md.ReturnType.Identifier);
+
+                CompareIgnoreFormatting(@"
+                ClassTwo classTwo = new ClassTwo();
+                System.debug('Test');", md.CodeInsideMethod);
+            }
         }
 
-        [Test(Description = @"\ApexParser\SalesForceApexSharp\src\classes\ClassTwo.cls"), Ignore("TODO: add constructors to the grammar")]
-        public void ClassTwoTest()
+        [Test(Description = @"\ApexParser\SalesForceApexSharp\src\classes\ClassTwo.cls")]
+        public void ClassTwoIsParsed()
         {
-            var cd = Apex.ClassDeclaration.Parse(Resources.ClassTwo);
-            Assert.AreEqual("ClassTwo", cd.Identifier);
-            Assert.AreEqual(2, cd.Methods.Count);
+            ParseAndValidate(ClassTwo);
+            ParseAndValidate(ClassTwo_Formatted);
 
-            var md = cd.Methods[0];
-            Assert.AreEqual("TestMethodOne", md.Identifier);
-            Assert.False(md.CodeComments.Any());
-            Assert.AreEqual(1, md.Attributes.Count);
-            Assert.AreEqual("isTest", md.Attributes[0]);
-            Assert.AreEqual(2, md.Modifiers.Count);
-            Assert.AreEqual("public", md.Modifiers[0]);
-            Assert.AreEqual("static", md.Modifiers[1]);
-            Assert.AreEqual("void", md.ReturnType.Identifier);
-            Assert.AreEqual("System.debug('TestMethodOne');", md.CodeInsideMethod);
+            void ParseAndValidate(string text)
+            {
+                var cd = Apex.ClassDeclaration.Parse(text);
+                Assert.AreEqual("ClassTwo", cd.Identifier);
+                Assert.AreEqual(2, cd.Methods.Count);
 
-            md = cd.Methods[1];
-            Assert.AreEqual("TestMethodThree", md.Identifier);
-            Assert.False(md.CodeComments.Any());
-            Assert.AreEqual(1, md.Attributes.Count);
-            Assert.AreEqual("isTest", md.Attributes[0]);
-            Assert.AreEqual(1, md.Modifiers.Count);
-            Assert.AreEqual("static", md.Modifiers[0]);
-            Assert.AreEqual("void", md.ReturnType.Identifier);
-            Assert.AreEqual("System.debug('TestMethodThree');", md.CodeInsideMethod);
+                var md = cd.Methods[0];
+                Assert.AreEqual("ClassTwo", md.Identifier);
+                Assert.False(md.CodeComments.Any());
+                Assert.False(md.Attributes.Any());
+                Assert.AreEqual(1, md.Modifiers.Count);
+                Assert.AreEqual("public", md.Modifiers[0]);
+                Assert.AreEqual("ClassTwo", md.ReturnType.Identifier);
+                Assert.AreEqual("System.debug('Test');", md.CodeInsideMethod);
+
+                md = cd.Methods[1];
+                Assert.AreEqual("ClassTwo", md.Identifier);
+                Assert.False(md.CodeComments.Any());
+                Assert.False(md.Attributes.Any());
+                Assert.AreEqual(1, md.Modifiers.Count);
+                Assert.AreEqual("public", md.Modifiers[0]);
+                Assert.AreEqual("ClassTwo", md.ReturnType.Identifier);
+                Assert.AreEqual(string.Empty, md.CodeInsideMethod);
+            }
         }
 
-        [Test(Description = @"\ApexParser\SalesForceApexSharp\src\classes\Demo.cls"), Ignore("TODO: match open/closed braces")]
-        public void DemoTest()
+        [Test]
+        public void ClassWithCommentsIsParsed()
+        {
+            ParseAndValidate(ClassWithComments);
+            ParseAndValidate(ClassWithComments_Formatted);
+
+            void ParseAndValidate(string text)
+            {
+                var cd = Apex.ClassDeclaration.Parse(text);
+                Assert.AreEqual("ClassTwo", cd.Identifier);
+                Assert.AreEqual(3, cd.Methods.Count);
+
+                var md = cd.Methods[0];
+                Assert.AreEqual("ClassTwo", md.Identifier);
+                Assert.False(md.CodeComments.Any());
+                Assert.False(md.Attributes.Any());
+                Assert.False(md.MethodParameters.Any());
+                Assert.AreEqual(1, md.Modifiers.Count);
+                Assert.AreEqual("public", md.Modifiers[0]);
+                Assert.AreEqual("ClassTwo", md.ReturnType.Identifier);
+                CompareIgnoreFormatting(@"
+                    // constructor
+                    System.debug('Test');", md.CodeInsideMethod);
+
+                md = cd.Methods[1];
+                Assert.AreEqual("ClassTwo", md.Identifier);
+                Assert.False(md.CodeComments.Any());
+                Assert.False(md.Attributes.Any());
+                Assert.AreEqual(1, md.Modifiers.Count);
+                Assert.AreEqual("public", md.Modifiers[0]);
+                Assert.AreEqual("ClassTwo", md.ReturnType.Identifier);
+                CompareIgnoreFormatting(@"
+                    // another constructor
+                    // with a lot of misplaced comments", md.CodeInsideMethod);
+                Assert.AreEqual(1, md.MethodParameters.Count);
+
+                var mp = md.MethodParameters[0];
+                Assert.AreEqual("String", mp.Type.Identifier);
+                Assert.False(mp.Type.TypeParameters.Any());
+                Assert.AreEqual("vin", mp.Identifier);
+
+                md = cd.Methods[2];
+                Assert.AreEqual("Hello", md.Identifier);
+                Assert.AreEqual(1, md.CodeComments.Count);
+                CompareIgnoreFormatting(@"
+                * This  is a comment line one
+                * This is a comment // line two", md.CodeComments[0]);
+
+                Assert.False(md.Attributes.Any());
+                Assert.False(md.MethodParameters.Any());
+                Assert.AreEqual(1, md.Modifiers.Count);
+                Assert.AreEqual("public", md.Modifiers[0]);
+                Assert.AreEqual("void", md.ReturnType.Identifier);
+                CompareIgnoreFormatting(@"System.debug('Hello');", md.CodeInsideMethod);
+            }
+        }
+
+        [Test(Description = @"\ApexParser\SalesForceApexSharp\src\classes\Demo.cls")]
+        public void DemoIsParsed()
         {
             var cd = Apex.ClassDeclaration.Parse(Resources.Demo);
             Assert.AreEqual("Demo", cd.Identifier);
             Assert.AreEqual(1, cd.Methods.Count);
+
+            var md = cd.Methods[0];
+            Assert.AreEqual("RunContactDemo", md.Identifier);
+            Assert.False(md.CodeComments.Any());
+            Assert.False(md.Attributes.Any());
+            Assert.AreEqual(2, md.Modifiers.Count);
+            Assert.AreEqual("public", md.Modifiers[0]);
+            Assert.AreEqual("static", md.Modifiers[1]);
+            Assert.AreEqual("void", md.ReturnType.Identifier);
+            CompareIgnoreFormatting(@"Contact contactNew = new Contact(LastName = 'Jay1', EMail = 'abc@abc.com');
+                insert contactNew;
+                System.debug(contactNew.Id);
+
+                List<Contact> contacts = [SELECT Id, Email FROM Contact WHERE Id = :contactNew.Id];
+                for (Contact c : contacts)
+                {
+                    System.debug(c.Email); c.Email = 'new@new.com';
+                }
+                update contacts;
+                contacts = [SELECT Id, Email FROM Contact WHERE Id = :contactNew.Id];
+                for (Contact c : contacts)
+                {
+                    System.debug(c.Email);
+                }
+                delete contacts;
+                contacts = [SELECT Id, Email FROM Contact WHERE Id = :contactNew.Id];
+                if (contacts.isEmpty())
+                {
+                    System.debug('Del Worked');
+                }", md.CodeInsideMethod);
         }
     }
 }

--- a/ApexParserTest/Parser/ApexResourceTests.cs
+++ b/ApexParserTest/Parser/ApexResourceTests.cs
@@ -159,7 +159,7 @@ namespace ApexParserTest.Parser
         [Test(Description = @"\ApexParser\SalesForceApexSharp\src\classes\Demo.cls")]
         public void DemoIsParsed()
         {
-            var cd = Apex.ClassDeclaration.Parse(Resources.Demo);
+            var cd = Apex.ClassDeclaration.Parse(Demo);
             Assert.AreEqual("Demo", cd.Identifier);
             Assert.AreEqual(1, cd.Methods.Count);
 
@@ -194,7 +194,7 @@ namespace ApexParserTest.Parser
                 }", md.CodeInsideMethod);
         }
 
-        [Test]
+        [Test(Description = @"\ApexParser\SalesForceApexSharp\src\classes\CustomerDto.cls")]
         public void CustomerDtoIsParsed()
         {
             ParseAndValidate(CustomerDto);

--- a/ApexParserTest/Properties/Resources.Designer.cs
+++ b/ApexParserTest/Properties/Resources.Designer.cs
@@ -153,16 +153,16 @@ namespace ApexParserTest.Properties {
         /// <summary>
         ///   Looks up a localized string similar to public with sharing class ClassTwo
         ///{
-        ///     // constructor
         ///     public ClassTwo()
         ///     {
+        ///          // constructor
         ///          System.debug(&apos;Test&apos;);
         ///     }
         ///
-        ///     // another constructor
-        ///     // with a lot of misplaced comments
         ///     public ClassTwo(String vin)
         ///     {
+        ///          // another constructor
+        ///          // with a lot of misplaced comments
         ///     }
         ///
         ///     /*
@@ -179,6 +179,44 @@ namespace ApexParserTest.Properties {
         internal static string ClassWithComments_Formatted {
             get {
                 return ResourceManager.GetString("ClassWithComments_Formatted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to public class CustomerDto
+        ///{
+        ///    public String make {get;set;}
+        ///    public String year {get;set;}
+        ///    public CustomerDto.User user {get;set;}
+        ///
+        ///    public class User {
+        ///        public string userName {get;set;}
+        ///    }
+        ///}.
+        /// </summary>
+        internal static string CustomerDto {
+            get {
+                return ResourceManager.GetString("CustomerDto", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to public class CustomerDto
+        ///{
+        ///     public String make { get;set; }
+        ///     public String year { get;set; }
+        ///     public CustomerDto.User user { get;set; }
+        ///
+        ///     public class User
+        ///     {
+        ///          public string userName { get;set; }
+        ///     }
+        ///}
+        ///.
+        /// </summary>
+        internal static string CustomerDto_Formatted {
+            get {
+                return ResourceManager.GetString("CustomerDto_Formatted", resourceCulture);
             }
         }
         
@@ -210,7 +248,7 @@ namespace ApexParserTest.Properties {
         ///* This  is a comment line one
         ///* This is a comment // line two
         ///*/
-        ///public with sharing class FormatDemoInput
+        ///public with sharing class FormatDemo
         ///{
         ///    public Integer
         ///        dateOfBirth
@@ -240,20 +278,16 @@ namespace ApexParserTest.Properties {
         ///*/
         ///public with sharing class FormatDemo
         ///{
-        ///    public Integer dateOfBirth { get; set; }
-        ///    public void ForLoopTest()
-        ///    {
-        ///        for (Integer i = 0; i &lt; 10; i++)
-        ///        {
-        ///            // This is a middle line comment
-        ///            List&lt;Contact&gt; contacts =
-        ///            [
-        ///            	SELECT Name, Email 
-        ///            	From Contact Where 
-        ///            	Name = &apos;Jay&apos;
-        ///            ];
-        ///        }
-        ///    }
+        ///     public Integer dateOfBirth { get; set; }
+        ///
+        ///     public void ForLoopTest()
+        ///     {
+        ///          for (Integer i = 0; i &lt; 10; i++)
+        ///          {
+        ///               // This is a middle line comment
+        ///               List&lt;Contact&gt; contacts = [ SELECT Name, Email From Contact Where Name = &apos;Jay&apos; ];
+        ///          }
+        ///     }
         ///}
         ///.
         /// </summary>

--- a/ApexParserTest/Properties/Resources.Designer.cs
+++ b/ApexParserTest/Properties/Resources.Designer.cs
@@ -134,6 +134,7 @@ namespace ApexParserTest.Properties {
         ///    }
         ///
         ///    public ClassTwo(String vin) { // another constructor
+        ///    // with a lot of misplaced comments
         ///    }
         ///
         ///    /*
@@ -152,26 +153,28 @@ namespace ApexParserTest.Properties {
         /// <summary>
         ///   Looks up a localized string similar to public with sharing class ClassTwo
         ///{
-        ///    public ClassTwo()
-        ///    {
-        ///         // constructor
-        ///         System.debug(&apos;Test&apos;);
-        ///    }
+        ///     // constructor
+        ///     public ClassTwo()
+        ///     {
+        ///          System.debug(&apos;Test&apos;);
+        ///     }
         ///
-        ///    public ClassTwo(String vin)
-        ///    {
-        ///         // another constructor
-        ///    }
+        ///     // another constructor
+        ///     // with a lot of misplaced comments
+        ///     public ClassTwo(String vin)
+        ///     {
+        ///     }
         ///
-        ///    /*
+        ///     /*
         ///     * This  is a comment line one
         ///     * This is a comment // line two
         ///     */
-        ///    public void Hello()
-        ///    {
-        ///         System.debug(&apos;Hello&apos;);
-        ///   	}
-        ///}.
+        ///     public void Hello()
+        ///     {
+        ///          System.debug(&apos;Hello&apos;);
+        ///     }
+        ///}
+        ///.
         /// </summary>
         internal static string ClassWithComments_Formatted {
             get {
@@ -199,6 +202,64 @@ namespace ApexParserTest.Properties {
         internal static string Demo {
             get {
                 return ResourceManager.GetString("Demo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to /*
+        ///* This  is a comment line one
+        ///* This is a comment // line two
+        ///*/
+        ///public with sharing class FormatDemoInput
+        ///{
+        ///    public Integer
+        ///        dateOfBirth
+        ///            { get; set; }
+        ///    public void ForLoopTest() {
+        ///        for (Integer i = 0; i &lt; 10; i++) {
+        ///            List&lt;Contact&gt; contacts =
+        ///            [
+        ///                    SELECT Name, Email // This is a middle line comment
+        ///                    From Contact
+        ///                    Where Name = &apos;Jay&apos;
+        ///            ];
+        ///        }
+        ///    }
+        ///}.
+        /// </summary>
+        internal static string FormatDemo {
+            get {
+                return ResourceManager.GetString("FormatDemo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to /*
+        ///* This  is a comment line one
+        ///* This is a comment // line two
+        ///*/
+        ///public with sharing class FormatDemo
+        ///{
+        ///    public Integer dateOfBirth { get; set; }
+        ///    public void ForLoopTest()
+        ///    {
+        ///        for (Integer i = 0; i &lt; 10; i++)
+        ///        {
+        ///            // This is a middle line comment
+        ///            List&lt;Contact&gt; contacts =
+        ///            [
+        ///            	SELECT Name, Email 
+        ///            	From Contact Where 
+        ///            	Name = &apos;Jay&apos;
+        ///            ];
+        ///        }
+        ///    }
+        ///}
+        ///.
+        /// </summary>
+        internal static string FormatDemo_Formatted {
+            get {
+                return ResourceManager.GetString("FormatDemo_Formatted", resourceCulture);
             }
         }
     }

--- a/ApexParserTest/Properties/Resources.resx
+++ b/ApexParserTest/Properties/Resources.resx
@@ -139,4 +139,10 @@
   <data name="Demo" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\ApexTestClasses\Demo.cls;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1251</value>
   </data>
+  <data name="FormatDemo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\ApexTestClasses\FormatDemo.cls;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1251</value>
+  </data>
+  <data name="FormatDemo_Formatted" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\ApexTestClasses\FormatDemo_Formatted.cls;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1251</value>
+  </data>
 </root>

--- a/ApexParserTest/Properties/Resources.resx
+++ b/ApexParserTest/Properties/Resources.resx
@@ -136,6 +136,12 @@
   <data name="ClassWithComments_Formatted" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\ApexTestClasses\ClassWithComments_Formatted.cls;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1251</value>
   </data>
+  <data name="CustomerDto" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\ApexTestClasses\CustomerDto.cls;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1251</value>
+  </data>
+  <data name="CustomerDto_Formatted" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\ApexTestClasses\CustomerDto_Formatted.cls;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1251</value>
+  </data>
   <data name="Demo" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\ApexTestClasses\Demo.cls;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1251</value>
   </data>


### PR DESCRIPTION
* Fixed the formatting for the use cases as discussed by email
* Added support for nested blocks in the method bodies
* Added support for properties, constructors and nested classes to the grammar
* Enabled the ignored tests: ClassOne, ClassTwo, Demo

Resource-based unit tests now parse both the original and the formatted 
versions of ClassOne and ClassTwo to make sure they produce the same AST.

Formatting sample. The original code:
```apex
/*
* This  is a comment line one
* This is a comment // line two
*/
public with sharing class FormatDemo
{
    public Integer
        dateOfBirth
            { get; set; }
    public void ForLoopTest() {
        for (Integer i = 0; i < 10; i++) {
            List<Contact> contacts =
            [
                    SELECT Name, Email // This is a middle line comment
                    From Contact
                    Where Name = 'Jay'
            ];
        }
    }
}
```
Formatted code:
```apex
/*
* This  is a comment line one
* This is a comment // line two
*/
public with sharing class FormatDemo
{
     public Integer dateOfBirth { get; set; }

     public void ForLoopTest()
     {
          for (Integer i = 0; i < 10; i++)
          {
               // This is a middle line comment
               List<Contact> contacts = [ SELECT Name, Email From Contact Where Name = 'Jay' ];
          }
     }
}
```